### PR TITLE
Set ubuntu22.04 as base image; Bump torch and lighting

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,18 +10,17 @@ jobs:
     name: Run pre-commit hooks
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      packages: read
-      statuses: write
-
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-      - uses: pre-commit-ci/lite-action@v1.0.1
-        if: always()
+      - name: Set up Python
+        uses: actions/setup-python@v3
         with:
-          msg: apply pre-commit hooks
+          python-version: "3.10"
+
+      - name: Install pre-commit
+        run: pip install -r requirements-dev.txt
+
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/dockerfiles/cuda118/Dockerfile
+++ b/dockerfiles/cuda118/Dockerfile
@@ -1,13 +1,11 @@
-FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+FROM ubuntu:22.04
 
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	python3 \
+	python3-pip \
 	curl && \
 	apt clean && \
 	rm -rf /var/lib/apt/lists/*
-
-RUN curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
-	python3 /tmp/get-pip.py
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt --extra-index-url https://download.pytorch.org/whl/cu118

--- a/dockerfiles/cuda120/Dockerfile
+++ b/dockerfiles/cuda120/Dockerfile
@@ -1,13 +1,11 @@
-FROM nvidia/cuda:12.0.1-cudnn8-runtime-ubuntu22.04
+FROM ubuntu:22.04
 
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	python3 \
+	python3-pip \
 	curl && \
 	apt clean && \
 	rm -rf /var/lib/apt/lists/*
-
-RUN curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
-	python3 /tmp/get-pip.py
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-pre-commit~=3.5.0
+pre-commit==3.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-lightning==2.1.2
+lightning==2.1.4
 protobuf==3.20.*
 segmentation-models-pytorch==0.3.3
 six==1.16.0
-torch==2.1.1
-torchvision==0.16.1
+torch==2.1.2
+torchvision==0.16.2


### PR DESCRIPTION
Torch actually comes with cuda and cudnn included so we don't need it in the base image.

Reduces image size by ~4GB

https://discuss.pytorch.org/t/does-pytorch-use-the-cudatoolkit-in-docker-or-the-system/140303

* Switch from pre-commit github package to a local runtime in actions
 * Bump torch and lightning